### PR TITLE
alpine-dependencies: avoid dependency conflicts by pinning pyproj version

### DIFF
--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -117,6 +117,7 @@ ENV ADDITIONAL_PYTHON_PACKAGES="\
     joblib \
     threadpoolctl \
     scikit-learn \
+    pyproj>2.6.1,<3.5 \
     "
 # Fix for scikit-learn segmentation fault error
 # TODO: check if this can be removed in future
@@ -124,4 +125,4 @@ RUN apk add openblas openblas-dev lapack lapack-dev
 RUN pip3 install --upgrade $ADDITIONAL_PYTHON_PACKAGES
 
 # Duplicated in final images, only here to safe time
-RUN pip3 install -r https://raw.githubusercontent.com/mundialis/actinia_core/main/requirements.txt
+RUN pip3 install -r https://raw.githubusercontent.com/actinia-org/actinia_core/main/requirements.txt


### PR DESCRIPTION
Pinning pyproj should avoid version conflicts when shapely is installed later on.
I tested this with Alpine 3.17 though...