### PR TITLE
Add additional version info

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 .gitignore
 .travis

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -1,3 +1,11 @@
+FROM alpine:3.18 as version
+RUN apk add git
+
+COPY .git /src/actinia-docker/.git
+WORKDIR /src/actinia-docker
+RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt
+
+
 FROM mundialis/actinia:alpine-dependencies-2022-11-18 as base
 FROM mundialis/grass-py3-pdal:releasebranch_8_2-alpine as grass
 FROM mundialis/esa-snap:s1tbx-3885c70 as snap
@@ -15,6 +23,9 @@ ENV GISBASE ""
 ENV ACTINIA_CORE_VERSION=4.8.0
 
 USER root
+
+# Set actinia-docker version
+COPY --from=version /actinia-docker-version.txt /
 
 # ESA SNAP SETUP
 ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"

--- a/actinia-alpine/start.sh
+++ b/actinia-alpine/start.sh
@@ -30,6 +30,9 @@ if [ $status -ne 0 ]; then
   exit $status
 fi
 
+export ACTINIA_RUNNING_SINCE=`date`
+export ACTINIA_ADDITIONAL_VERSION_INFO="actinia_docker_version:`cat /actinia-docker-version.txt`"
+
 # optimized gunicorn settings (http://docs.gunicorn.org/en/stable/design.html) # run only 1 worker for debugging reasons. This is overwritten for production
 # deployment.
 gunicorn -b 0.0.0.0:8088 -w 8 --access-logfile=- -k gthread actinia_core.main:flask_app


### PR DESCRIPTION
This PR suggests to add `actinia_docker_version` and to populate `running_since`. Example:

```
{
  "actinia_docker_version": "2.5.7-12-ge341ea7-dirty", 
  "api_version": "3.4.0", 
  "grass_version": {
    "build_date": "2023-06-04", 
    "build_off_t_size": "8", 
    "build_platform": "x86_64-pc-linux-musl", 
    "date": "2023", 
    "gdal": "3.6.4", 
    "geos": "3.11.2", 
    "libgis_date": "2023-06-04T08:53:24+00:00", 
    "libgis_revision": "8.2.2dev", 
    "proj": "9.2.1", 
    "revision": "10d4b93", 
    "sqlite": "3.41.2", 
    "version": "8.2.2dev"
  }, 
  "plugin_versions": {
    "actinia_metadata_plugin": "1.0.2", 
    "actinia_module_plugin": "2.5.0", 
    "actinia_satellite_plugin": "0.1.0", 
    "actinia_stac_plugin": "0.1.1", 
    "actinia_statistic_plugin": "0.2.1"
  }, 
  "plugins": "actinia_statistic_plugin,actinia_satellite_plugin,actinia_metadata_plugin,actinia_module_plugin,actinia_stac_plugin", 
  "python_version": "3.11.3 (main, May 10 2023, 12:26:31) [GCC 12.2.1 20220924]", 
  "running_since": "Mon Jun  5 15:36:14 UTC 2023", 
  "version": "4.8.0"
}
```