### PR TITLE
Add git fetch depth to action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - id: meta
         name: Create tag name
         run: |
@@ -77,6 +79,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Create image and tag names
         id: meta
         uses: docker/metadata-action@v4


### PR DESCRIPTION
The docker pipeline currently fails with
```
 > [version 5/5] RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt:
232
#0 0.091 fatal: No names found, cannot describe anything.
```
This PR tries to solve this.