### PR TITLE
Use pyproj releases again

### DIFF
--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -121,7 +121,7 @@ ENV ADDITIONAL_PYTHON_PACKAGES="\
     joblib \
     threadpoolctl \
     scikit-learn \
-    pyproj@git+https://github.com/pyproj4/pyproj.git@main \
+    pyproj>=3.6.1 \
     "
 # Fix for scikit-learn segmentation fault error
 # TODO: check if this can be removed in future


### PR DESCRIPTION
Undo https://github.com/actinia-org/actinia-docker/pull/48 after new [pyproj release ](https://github.com/pyproj4/pyproj/releases/tag/3.6.1).