### PR TITLE
Re-enable SNAP but without Snappy

### DIFF
--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -30,9 +30,11 @@ COPY --from=version /actinia-docker-version.txt /
 ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"
 COPY --from=snap /root/.snap /root/.snap
 COPY --from=snap /usr/local/snap /usr/local/snap
+# commenting out snappy configuration:
 # RUN (cd /root/.snap/snap-python/snappy && pip3 install .)
 # RUN /usr/bin/python3 -c 'from snappy import ProductIO'
 # RUN /usr/bin/python3 /root/.snap/about.py
+# using gpt (graph processing tool) instead:
 # add gpt to PATH
 ENV PATH="${PATH}:/usr/local/snap/bin"
 # test gpt
@@ -53,6 +55,7 @@ RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
 # GRASS GIS addons installation
 # git clone various openEO plugins (local checkout due to non-standard repo structure)
 RUN git clone https://github.com/mundialis/openeo-addons.git /src/openeo-addons
+RUN git clone https://github.com/NVE/actinia_modules_nve.git /src/nve-addons
 
 # TODO: Fix requirements installation for openeo-udf, needed by t.rast.udf.
 # RUN git clone https://github.com/Open-EO/openeo-udf.git /src/openeo-udf
@@ -133,6 +136,7 @@ RUN mkdir -p /actinia_core/grassdb && \
 VOLUME /grassdb
 WORKDIR /src/actinia_core
 
+# install GDAL GRASS plugin (required for i.sentinel1.pyrosargeocode)
 RUN mkdir -p /usr/lib/gdalplugins
 RUN git clone https://github.com/OSGeo/gdal-grass.git
 RUN cd gdal-grass && ./configure --with-gdal=/usr/bin/gdal-config --with-grass=/usr/local/grass83 \

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -7,7 +7,7 @@ RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.
 
 FROM actinia:alpine-dependencies as base
 FROM osgeo/grass-gis:releasebranch_8_3-alpine as grass
-FROM mundialis/esa-snap:s1tbx-c149a5b
+FROM mundialis/esa-snap:s1tbx-c149a5b as snap
 
 FROM base
 

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -5,7 +5,7 @@ COPY .git /src/actinia-docker/.git
 WORKDIR /src/actinia-docker
 RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt
 
-FROM actinia:alpine-dependencies as base
+FROM mundialis/actinia:alpine-dependencies-2024-04-17 as base
 FROM osgeo/grass-gis:releasebranch_8_3-alpine as grass
 FROM mundialis/esa-snap:s1tbx-c149a5b as snap
 

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -7,7 +7,7 @@ RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.
 
 FROM actinia:alpine-dependencies as base
 FROM osgeo/grass-gis:releasebranch_8_3-alpine as grass
-FROM esa-snap_no_snappy_test as snap
+FROM mundialis/esa-snap:s1tbx-c149a5b
 
 FROM base
 
@@ -30,10 +30,6 @@ COPY --from=version /actinia-docker-version.txt /
 ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"
 COPY --from=snap /root/.snap /root/.snap
 COPY --from=snap /usr/local/snap /usr/local/snap
-# commenting out snappy configuration:
-# RUN (cd /root/.snap/snap-python/snappy && pip3 install .)
-# RUN /usr/bin/python3 -c 'from snappy import ProductIO'
-# RUN /usr/bin/python3 /root/.snap/about.py
 # using gpt (graph processing tool) instead:
 # add gpt to PATH
 ENV PATH="${PATH}:/usr/local/snap/bin"

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -5,9 +5,9 @@ COPY .git /src/actinia-docker/.git
 WORKDIR /src/actinia-docker
 RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt
 
-FROM mundialis/actinia:alpine-dependencies-2023-11-02 as base
+FROM actinia:alpine-dependencies as base
 FROM osgeo/grass-gis:releasebranch_8_3-alpine as grass
-# FROM mundialis/esa-snap:s1tbx-8c195c8 as snap
+FROM esa-snap_no_snappy_test as snap
 
 FROM base
 
@@ -27,12 +27,16 @@ USER root
 COPY --from=version /actinia-docker-version.txt /
 
 # # ESA SNAP SETUP
-# ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"
-# COPY --from=snap /root/.snap /root/.snap
-# COPY --from=snap /usr/local/snap /usr/local/snap
+ENV LD_LIBRARY_PATH ".:$LD_LIBRARY_PATH"
+COPY --from=snap /root/.snap /root/.snap
+COPY --from=snap /usr/local/snap /usr/local/snap
 # RUN (cd /root/.snap/snap-python/snappy && pip3 install .)
 # RUN /usr/bin/python3 -c 'from snappy import ProductIO'
 # RUN /usr/bin/python3 /root/.snap/about.py
+# add gpt to PATH
+ENV PATH="${PATH}:/usr/local/snap/bin"
+# test gpt
+RUN gpt -h
 
 # GRASS GIS SETUP
 COPY --from=grass /usr/local/bin/grass /usr/local/bin/grass

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -41,6 +41,9 @@ RUN gpt -h
 # GRASS GIS SETUP
 COPY --from=grass /usr/local/bin/grass /usr/local/bin/grass
 COPY --from=grass /usr/local/grass* /usr/local/grass/
+# COPY --from=grass /usr/lib/gdalplugins/*_GRASS* /usr/lib/gdalplugins/
+COPY --from=grass /usr/local/grass/etc/proj/ /etc/proj/
+COPY --from=grass /usr/local/grass/etc/colors/ /etc/colors/
 RUN pip3 install --upgrade pip six grass-session --ignore-installed six
 RUN ln -s /usr/local/grass `grass --config path`
 RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
@@ -129,6 +132,12 @@ RUN mkdir -p /actinia_core/grassdb && \
 
 VOLUME /grassdb
 WORKDIR /src/actinia_core
+
+RUN mkdir -p /usr/lib/gdalplugins
+RUN git clone https://github.com/OSGeo/gdal-grass.git
+RUN cd gdal-grass && ./configure --with-gdal=/usr/bin/gdal-config --with-grass=/usr/local/grass83 \
+&& make && make install
+RUN cd .. && rm -rf gdal-grass
 
 ENTRYPOINT ["/bin/sh"]
 CMD ["/src/start.sh"]

--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -122,6 +122,7 @@ ENV ADDITIONAL_PYTHON_PACKAGES="\
     threadpoolctl \
     scikit-learn \
     pyproj>=3.6.1 \
+    pyroSAR \
     "
 # Fix for scikit-learn segmentation fault error
 # TODO: check if this can be removed in future

--- a/grass_addons_list.csv
+++ b/grass_addons_list.csv
@@ -37,3 +37,4 @@ t.rast.resample,/src/openeo-addons/t.rast.resample
 # t.rast.udf,/src/openeo-addons/t.rast.udf
 t.rast2strds,/src/openeo-addons/t.rast2strds
 v.in.geojson,/src/openeo-addons/v.in.geojson
+i.sentinel1.pyrosargeocode,https://github.com/NVE/actinia_modules_nve

--- a/grass_addons_list.csv
+++ b/grass_addons_list.csv
@@ -37,5 +37,4 @@ t.rast.resample,/src/openeo-addons/t.rast.resample
 # t.rast.udf,/src/openeo-addons/t.rast.udf
 t.rast2strds,/src/openeo-addons/t.rast2strds
 v.in.geojson,/src/openeo-addons/v.in.geojson
-# todo: how to add -o to g.extension?
-i.sentinel1.pyrosargeocode,https://github.com/NVE/actinia_modules_nve
+i.sentinel1.pyrosargeocode,/src/nve-addons/src/imagery/i.sentinel1.pyrosargeocode

--- a/grass_addons_list.csv
+++ b/grass_addons_list.csv
@@ -37,4 +37,5 @@ t.rast.resample,/src/openeo-addons/t.rast.resample
 # t.rast.udf,/src/openeo-addons/t.rast.udf
 t.rast2strds,/src/openeo-addons/t.rast2strds
 v.in.geojson,/src/openeo-addons/v.in.geojson
+# todo: how to add -o to g.extension?
 i.sentinel1.pyrosargeocode,https://github.com/NVE/actinia_modules_nve


### PR DESCRIPTION
In order to run [i.sentinel.1pyrosargeocode](https://nve.github.io/actinia_modules_nve/i.sentinel1.pyrosargeocode.html) as an alternative to snappy S-1 preprocessing, snappy has to be removed from the installation, but SNAP still needs to be installed with `gpt` enabled (see https://github.com/mundialis/esa-snap/pull/37)