### PR TITLE
Update to alpine 3.19

### DIFF
--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:3.18 as version
+FROM alpine:3.19 as version
 RUN apk add git
 
 COPY .git /src/actinia-docker/.git
 WORKDIR /src/actinia-docker
 RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt
 
-FROM mundialis/actinia:alpine-dependencies-2023-11-02 as base
-FROM osgeo/grass-gis:releasebranch_8_3-alpine as grass
-# FROM mundialis/esa-snap:s1tbx-8c195c8 as snap
+FROM actinia:alpine-dependencies-20240403 as base
+FROM osgeo/grass-gis:main-alpine as grass
+# FROM mundialis/esa-snap:s1tbx-c149a5b as snap
 
 FROM base
 

--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19
 
 ENV ACTINIA_BUILD_PACKAGES="\
     gcc \
@@ -109,7 +109,9 @@ RUN apk update; \
         $GOOGLE_CLOUD_BIGQUERY_PACKAGES \
         $ACTINIA_RUNTIME_PACKAGES
 
-RUN python3 -m ensurepip && pip3 install --upgrade pip pep517 wheel
+ENV PATH="/opt/venv/bin:$PATH"
+RUN /usr/bin/python -m venv --system-site-packages --without-pip /opt/venv
+RUN python -m ensurepip && pip3 install --upgrade pip pep517 wheel
 
 # Do not sort alphabetically as some depend on others
 ENV ADDITIONAL_PYTHON_PACKAGES="\
@@ -125,7 +127,7 @@ ENV ADDITIONAL_PYTHON_PACKAGES="\
     "
 # Fix for scikit-learn segmentation fault error
 # TODO: check if this can be removed in future
-RUN apk add openblas openblas-dev lapack-dev
+# RUN apk add openblas openblas-dev lapack-dev
 RUN pip3 install --upgrade $ADDITIONAL_PYTHON_PACKAGES
 
 # Duplicated in final images, only here to safe time


### PR DESCRIPTION
Tested locally. Success with https://github.com/actinia-org/actinia-core/pull/506

GRASS GIS release 8.4 is needed to merge this (TODO: adjust image tag in this PR before) as the actinia alpine build uses a release branch and not main branch. This is currently releasebranch 8.3 in which the alpine Dockerimage is build on alpine 3.18.
https://github.com/OSGeo/grass/releases
It is necessary that GRASS GIS and actinia share the same alpine version to e.g. have identical GDAL versions.