### PR TITLE
Update to alpine 3.20

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,63 +43,72 @@
 				// while not using docker-compose for startup
 				"network": "actinia-docker_actinia-dev",
 				"ports": [
-				  {
-					"containerPort": 8088,
-					"hostPort": 8088
-				  }
+					{
+						"containerPort": 8088,
+						"hostPort": 8088
+					}
 				],
 				"customOptions": "--ip 172.18.0.11",
 				"volumes": [
 					// mount local source code for instant reload
 					// on changes
 					{
-				        "localPath": "${workspaceFolder}/actinia-core",
-					    "containerPath": "/src/actinia_core",
-					    "permissions": "rw"
-				    },
+						"localPath": "${workspaceFolder}/actinia-core",
+						"containerPath": "/src/actinia_core",
+						"permissions": "rw"
+					},
 					// mount GRASS DBs
 					{
 						"localPath": "${workspaceFolder}/actinia-docker/actinia-data/grassdb",
-
-					    "containerPath": "/actinia_core/grassdb",
-					    "permissions": "rw"
-				    },
+						"containerPath": "/actinia_core/grassdb",
+						"permissions": "rw"
+					},
 					{
 						"localPath": "${workspaceFolder}/actinia-docker/actinia-data/userdata",
-					    "containerPath": "/actinia_core/userdata",
-					    "permissions": "rw"
-				    },
+						"containerPath": "/actinia_core/userdata",
+						"permissions": "rw"
+					},
 					// mount other data
 					{
-				    	"localPath": "${workspaceFolder}/actinia-docker/actinia-data/pgpass",
-					    "containerPath": "/mnt/pgpass",
-					    "permissions": "rw"
-				    },
+						"localPath": "${workspaceFolder}/actinia-docker/actinia-data/pgpass",
+						"containerPath": "/mnt/pgpass",
+						"permissions": "rw"
+					},
 					{
-				    	"localPath": "${workspaceFolder}/actinia-docker/actinia-data/geodata_dir",
-					    "containerPath": "/mnt/geodata",
-					    "permissions": "rw"
-				    },
+						"localPath": "${workspaceFolder}/actinia-docker/actinia-data/geodata_dir",
+						"containerPath": "/mnt/geodata",
+						"permissions": "rw"
+					},
 					{
-				    	"localPath": "${workspaceFolder}/actinia-docker/actinia-data/workspace",
-					    "containerPath": "/actinia_core/workspace",
-					    "permissions": "rw"
-				    },
+						"localPath": "${workspaceFolder}/actinia-docker/actinia-data/workspace",
+						"containerPath": "/actinia_core/workspace",
+						"permissions": "rw"
+					},
 					{
-				    	"localPath": "${workspaceFolder}/actinia-docker/actinia-data/resources",
-					    "containerPath": "/actinia_core/resources",
-					    "permissions": "rw"
-				    },
+						"localPath": "${workspaceFolder}/actinia-docker/actinia-data/resources",
+						"containerPath": "/actinia_core/resources",
+						"permissions": "rw"
+					},
 					// mount plugin code on-demand
-					// {
-					// 	"localPath": "${workspaceFolder}/actinia-module-plugin/",
-					//     "containerPath": "/src/actinia-module-plugin/",
-					//     "permissions": "rw"
-					// },
 					// {
 					// 	"localPath": "${workspaceFolder}/actinia-metadata-plugin/",
 					//     "containerPath": "/src/actinia-metadata-plugin/",
 					//     "permissions": "rw"
+					// },
+					// {
+					// 	"localPath": "${workspaceFolder}/actinia-module-plugin/",
+					// 	"containerPath": "/src/actinia-module-plugin/",
+					// 	"permissions": "rw"
+					// },
+					// {
+					// 	"localPath": "${workspaceFolder}/actinia-parallel-plugin/",
+					//      "containerPath": "/src/actinia-parallel-plugin/",
+					//      "permissions": "rw"
+					// },
+					// {
+					// 	"localPath": "${workspaceFolder}/actinia-satellite-plugin/",
+					// 	"containerPath": "/src/actinia_satellite_plugin/",
+					// 	"permissions": "rw"
 					// },
 					// {
 					// 	"localPath": "${workspaceFolder}/actinia-stac-plugin/",
@@ -112,8 +121,8 @@
 					//     "permissions": "rw"
 					// },
 					// {
-					// 	"localPath": "${workspaceFolder}/actinia-satellite-plugin/",
-					//     "containerPath": "/src/actinia_satellite_plugin/",
+					// 	"localPath": "${workspaceFolder}/actinia-tiling-plugin/",
+					//     "containerPath": "/src/actinia_tiling_plugin/",
 					//     "permissions": "rw"
 					// },
 					// {

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -19,7 +19,7 @@ ENV GDAL_CACHEMAX=2000
 ENV GRASS_COMPRESSOR=ZSTD
 ENV GRASS_SKIP_MAPSET_OWNER_CHECK 1
 ENV GISBASE ""
-ENV ACTINIA_CORE_VERSION=4.14.0
+ENV ACTINIA_CORE_VERSION=4.14.1
 
 USER root
 
@@ -65,17 +65,17 @@ RUN while IFS=, read -r ADDON SERVER; do if [[ $ADDON != "#*" ]]; then unset URL
 # actinia-core and plugins installation
 WORKDIR /build
 
-ARG PLUGIN_VERSION=0.2.1
+ARG PLUGIN_VERSION=0.2.2
 ARG WHEEL_NAME=actinia_statistic_plugin-${PLUGIN_VERSION}-py2.py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia_statistic_plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
 
-ARG PLUGIN_VERSION=0.1.0
+ARG PLUGIN_VERSION=0.1.2
 ARG WHEEL_NAME=actinia_satellite_plugin-${PLUGIN_VERSION}-py2.py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia_satellite_plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
 
-ARG PLUGIN_VERSION=1.0.2
+ARG PLUGIN_VERSION=1.0.3
 ARG WHEEL_NAME=actinia_metadata_plugin.wsgi-${PLUGIN_VERSION}-py2.py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-metadata-plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
@@ -85,12 +85,12 @@ ARG WHEEL_NAME=actinia_module_plugin.wsgi-${PLUGIN_VERSION}-py2.py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-module-plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
 
-ARG PLUGIN_VERSION=0.1.1
+ARG PLUGIN_VERSION=0.2.1
 ARG WHEEL_NAME=actinia_stac_plugin.wsgi-${PLUGIN_VERSION}-py2.py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-stac-plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
 
-ARG PLUGIN_VERSION=1.0.0
+ARG PLUGIN_VERSION=1.0.2
 ARG WHEEL_NAME=actinia_tiling_plugin.wsgi-${PLUGIN_VERSION}-py2.py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-tiling-plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
@@ -100,7 +100,6 @@ ARG WHEEL_NAME=actinia_api-${ACTINIA_API_VERSION}-py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-api/releases/download/${ACTINIA_API_VERSION}/${WHEEL_NAME}
 
-# ARG WHEEL_NAME=actinia_core-${ACTINIA_CORE_VERSION}-py2.py3-none-any.whl
 ARG WHEEL_NAME=actinia_core-${ACTINIA_CORE_VERSION}-py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-core/releases/download/${ACTINIA_CORE_VERSION}/${WHEEL_NAME}

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -5,7 +5,7 @@ COPY .git /src/actinia-docker/.git
 WORKDIR /src/actinia-docker
 RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt
 
-FROM actinia:alpine-dependencies-20240618 as base
+FROM mundialis/actinia:alpine-dependencies-2024-06-26 as base
 FROM osgeo/grass-gis:releasebranch_8_4-alpine as grass
 FROM mundialis/esa-snap:s1tbx-543d1be as snap
 
@@ -80,8 +80,8 @@ ARG WHEEL_NAME=actinia_metadata_plugin.wsgi-${PLUGIN_VERSION}-py2.py3-none-any.w
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-metadata-plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
 
-ARG PLUGIN_VERSION=2.5.0
-ARG WHEEL_NAME=actinia_module_plugin.wsgi-${PLUGIN_VERSION}-py2.py3-none-any.whl
+ARG PLUGIN_VERSION=2.6.0
+ARG WHEEL_NAME=actinia_module_plugin-${PLUGIN_VERSION}-py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-module-plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
 

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -5,9 +5,9 @@ COPY .git /src/actinia-docker/.git
 WORKDIR /src/actinia-docker
 RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt
 
-FROM actinia:alpine-dependencies-20240614 as base
-FROM grass-gis:alpine-3.20 as grass
-FROM esa-snap:s1tbx-alpine3.20 as snap
+FROM actinia:alpine-dependencies-20240618 as base
+FROM osgeo/grass-gis:releasebranch_8_4-alpine as grass
+FROM mundialis/esa-snap:s1tbx-543d1be as snap
 
 FROM base
 
@@ -44,7 +44,7 @@ COPY --from=grass /usr/local/grass/etc/proj/ /etc/proj/
 COPY --from=grass /usr/local/grass/etc/colors/ /etc/colors/
 RUN pip3 install --upgrade pip six grass-session --ignore-installed six
 RUN ln -s /usr/local/grass `grass --config path`
-RUN grass --tmp-location EPSG:4326 --exec g.version -rge && \
+RUN grass --tmp-project EPSG:4326 --exec g.version -rge && \
     pdal --version && \
     python3 --version
 
@@ -60,7 +60,7 @@ RUN git clone https://github.com/NVE/actinia_modules_nve.git /src/nve-addons
 
 COPY grass_addons_list.csv /src/grass_addons_list.csv
 
-RUN while IFS=, read -r ADDON SERVER; do if [[ $ADDON != "#*" ]]; then unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-location EPSG:4326 --exec g.extension -s extension=$ADDON $URL;fi;done < /src/grass_addons_list.csv
+RUN while IFS=, read -r ADDON SERVER; do if [[ $ADDON != "#*" ]]; then unset URL; test -z $SERVER || URL="url=$SERVER"; grass --tmp-project EPSG:4326 --exec g.extension -s extension=$ADDON $URL;fi;done < /src/grass_addons_list.csv
 
 # actinia-core and plugins installation
 WORKDIR /build
@@ -95,7 +95,7 @@ ARG WHEEL_NAME=actinia_tiling_plugin.wsgi-${PLUGIN_VERSION}-py2.py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-tiling-plugin/releases/download/${PLUGIN_VERSION}/${WHEEL_NAME}
 
-ENV ACTINIA_API_VERSION=3.4.0
+ENV ACTINIA_API_VERSION=3.4.1
 ARG WHEEL_NAME=actinia_api-${ACTINIA_API_VERSION}-py3-none-any.whl
 RUN curl -L --output /build/${WHEEL_NAME} \
     https://github.com/actinia-org/actinia-api/releases/download/${ACTINIA_API_VERSION}/${WHEEL_NAME}
@@ -111,9 +111,6 @@ RUN curl -L --output /build/${WHEEL_NAME} \
 # though older ones are already installed.
 RUN for i in /build/*; do pip3 install $i; done
 
-# Duplicate install actinia_core requirements. They are already included
-# in alpine-build / alpine-runtime images, but check for updates here.
-RUN pip3 install -r https://raw.githubusercontent.com/actinia-org/actinia_core/${ACTINIA_CORE_VERSION}/requirements.txt
 
 # Copy actinia config file and start scripts + set needed envs
 COPY actinia-alpine/actinia.cfg /etc/default/actinia

--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:3.18 as version
+FROM alpine:3.20 as version
 RUN apk add git
 
 COPY .git /src/actinia-docker/.git
 WORKDIR /src/actinia-docker
 RUN git describe --dirty --tags --long --first-parent > /actinia-docker-version.txt
 
-FROM mundialis/actinia:alpine-dependencies-2024-05-24 as base
-FROM osgeo/grass-gis:releasebranch_8_3-alpine as grass
-FROM mundialis/esa-snap:s1tbx-c149a5b as snap
+FROM actinia:alpine-dependencies-20240614 as base
+FROM grass-gis:alpine-3.20 as grass
+FROM esa-snap:s1tbx-alpine3.20 as snap
 
 FROM base
 
@@ -135,7 +135,7 @@ WORKDIR /src/actinia_core
 # install GDAL GRASS plugin (required for i.sentinel1.pyrosargeocode)
 RUN mkdir -p /usr/lib/gdalplugins
 RUN git clone https://github.com/OSGeo/gdal-grass.git
-RUN cd gdal-grass && ./configure --with-gdal=/usr/bin/gdal-config --with-grass=/usr/local/grass83 \
+RUN cd gdal-grass && ./configure --with-gdal=/usr/bin/gdal-config --with-grass=/usr/local/grass84 \
 && make && make install
 RUN cd .. && rm -rf gdal-grass
 

--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.20
 
 ENV ACTINIA_BUILD_PACKAGES="\
     gcc \
@@ -24,7 +24,7 @@ ENV ACTINIA_REQUIREMENTS_WHEEL_PACKAGES="\
 
 ENV SNAPPY_RUNTIME_PACKAGES="\
     python3 \
-    openjdk8 \
+    openjdk11 \
     "
 
 ENV PDAL_RUNTIME_PACKAGES="\
@@ -109,7 +109,9 @@ RUN apk update; \
         $GOOGLE_CLOUD_BIGQUERY_PACKAGES \
         $ACTINIA_RUNTIME_PACKAGES
 
-RUN python3 -m ensurepip && pip3 install --upgrade pip pep517 wheel
+ENV PATH="/opt/venv/bin:$PATH"
+RUN /usr/bin/python -m venv --system-site-packages --without-pip /opt/venv
+RUN python -m ensurepip && pip3 install --upgrade pip pep517 wheel
 
 # Do not sort alphabetically as some depend on others
 ENV ADDITIONAL_PYTHON_PACKAGES="\
@@ -126,7 +128,7 @@ ENV ADDITIONAL_PYTHON_PACKAGES="\
     "
 # Fix for scikit-learn segmentation fault error
 # TODO: check if this can be removed in future
-RUN apk add openblas openblas-dev lapack-dev
+# RUN apk add openblas openblas-dev lapack-dev
 RUN pip3 install --upgrade $ADDITIONAL_PYTHON_PACKAGES
 
 # Duplicated in final images, only here to safe time

--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -131,5 +131,6 @@ ENV ADDITIONAL_PYTHON_PACKAGES="\
 # RUN apk add openblas openblas-dev lapack-dev
 RUN pip3 install --upgrade $ADDITIONAL_PYTHON_PACKAGES
 
+# Install actinia dependencies
 # Duplicated in final images, only here to safe time
-RUN pip3 install -r https://raw.githubusercontent.com/actinia-org/actinia_core/main/requirements.txt
+RUN pip3 install actinia-core && pip3 uninstall actinia-core -y

--- a/actinia-alpine/start.sh
+++ b/actinia-alpine/start.sh
@@ -15,11 +15,11 @@ chmod 0600 $HOME/.pgpass
 cp /mnt/pgpass/.grass8 $HOME/.grass8/dblogin
 chmod 0600 $HOME/.grass8/dblogin
 
-# copy db.login file to actinia-core tmp location
+# copy db.login file to actinia-core tmp project
 mkdir -p /tmp/:/root/.grass8
 cp /root/.grass8/dblogin /tmp/:/root/.grass8/
 
-# Create default location in mounted (!) directory
+# Create default project in mounted (!) directory
 [ ! -d "/actinia_core/grassdb/nc_spm_08" ] && grass --text -e -c 'EPSG:3358' /actinia_core/grassdb/nc_spm_08
 
 actinia-user create -u actinia-gdi -w actinia-gdi -r superadmin -g superadmin -c 100000000000 -n 1000 -t 31536000

--- a/actinia-dev/Dockerfile
+++ b/actinia-dev/Dockerfile
@@ -28,9 +28,24 @@ RUN pip3 install -e .
 
 # for actinia plugin development, incomment matching block
 
+# RUN pip3 uninstall actinia_metadata_plugin.wsgi -y
+# RUN git clone https://github.com/actinia-org/actinia-metadata-plugin.git /src/actinia-metadata-plugin
+# WORKDIR /src/actinia-metadata-plugin/
+# RUN pip3 install -e .
+
 # RUN pip3 uninstall actinia_module_plugin.wsgi -y
 # RUN git clone https://github.com/actinia-org/actinia-module-plugin.git /src/actinia-module-plugin
 # WORKDIR /src/actinia-module-plugin/
+# RUN pip3 install -e .
+
+# RUN pip3 uninstall actinia_parallel_plugin -y
+# RUN git clone https://github.com/actinia-org/actinia-parallel-plugin.git /src/actinia_parallel_plugin
+# WORKDIR /src/actinia_parallel_plugin/
+# RUN pip3 install -e .
+
+# RUN pip3 uninstall actinia_satellite_plugin -y
+# RUN git clone https://github.com/actinia-org/actinia-satellite-plugin.git /src/actinia_satellite_plugin
+# WORKDIR /src/actinia_satellite_plugin/
 # RUN pip3 install -e .
 
 # RUN pip3 uninstall actinia_stac_plugin.wsgi -y
@@ -38,19 +53,14 @@ RUN pip3 install -e .
 # WORKDIR /src/actinia-stac-plugin/
 # RUN pip3 install -e .
 
-# RUN pip3 uninstall actinia_metadata_plugin.wsgi -y
-# RUN git clone https://github.com/actinia-org/actinia-metadata-plugin.git /src/actinia-metadata-plugin
-# WORKDIR /src/actinia-metadata-plugin/
-# RUN pip3 install -e .
-
 # RUN pip3 uninstall actinia_statistic_plugin -y
 # RUN git clone https://github.com/actinia-org/actinia-statistic-plugin.git /src/actinia_statistic_plugin
 # WORKDIR /src/actinia_statistic_plugin/
 # RUN pip3 install -e .
 
-# RUN pip3 uninstall actinia_satellite_plugin -y
-# RUN git clone https://github.com/actinia-org/actinia-satellite-plugin.git /src/actinia_satellite_plugin
-# WORKDIR /src/actinia_satellite_plugin/
+# RUN pip3 uninstall actinia_tiling_plugin -y
+# RUN git clone https://github.com/actinia-org/actinia-tiling-plugin.git /src/actinia_tiling_plugin
+# WORKDIR /src/actinia_tiling_plugin/
 # RUN pip3 install -e .
 
 # RUN pip3 uninstall actinia_api -y


### PR DESCRIPTION
Update of actinia docker setup to alpine 3.20 and GRASS GIS 8.4

Related PRs:
- GRASS GIS update to alpine 3.20: https://github.com/OSGeo/grass/pull/3728
- https://github.com/actinia-org/actinia-docker/pull/87 Remove requirements.txt usage
- https://github.com/actinia-org/actinia-core/pull/518 chore(deps): update dependency setuptools to v70
- https://github.com/actinia-org/actinia-core/pull/527 Fix import error
- https://github.com/actinia-org/actinia-core/pull/530 Remove requirements.txt
- https://github.com/actinia-org/actinia-core/pull/531 Updates for g84 and python
- https://github.com/actinia-org/actinia-core/pull/534 Prepare for newer alpine and grass version 
- https://github.com/actinia-org/actinia-core/pull/535 Lint
 
Also new releases for plugins were necessary with import fix for each:
- https://github.com/actinia-org/actinia-parallel-plugin/releases/tag/1.0.1
- https://github.com/actinia-org/actinia-statistic-plugin/releases/tag/0.2.2
- https://github.com/actinia-org/actinia-satellite-plugin/releases/tag/0.1.2
- https://github.com/actinia-org/actinia-tiling-plugin/releases/tag/1.0.2
- https://github.com/actinia-org/actinia-metadata-plugin/releases/tag/1.0.3
- https://github.com/actinia-org/actinia-stac-plugin/releases/tag/0.2.1
- https://github.com/actinia-org/actinia-module-plugin/releases/tag/2.6.0- 