### PR TITLE
small fixes for dev-setup

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
 		{
 			"label": "start-valkey",
 			"type": "shell",
-			"command": "docker-compose -f actinia-docker/docker-compose-dev.yml up -d --force-recreate valkey",
+			"command": "docker compose -f actinia-docker/docker-compose-dev.yml up -d --force-recreate valkey",
 			"isBackground": true,
 		},
 		{

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -91,14 +91,19 @@
 					},
 					// mount plugin code on-demand
 					// {
+					// 	"localPath": "${workspaceFolder}/actinia-example-plugin/",
+					//     "containerPath": "/src/actinia-example-plugin/",
+					//     "permissions": "rw"
+					// },
+					// {
 					// 	"localPath": "${workspaceFolder}/actinia-metadata-plugin/",
 					//     "containerPath": "/src/actinia-metadata-plugin/",
 					//     "permissions": "rw"
 					// },
 					// {
 					// 	"localPath": "${workspaceFolder}/actinia-module-plugin/",
-					// 	"containerPath": "/src/actinia-module-plugin/",
-					// 	"permissions": "rw"
+					// 		"containerPath": "/src/actinia-module-plugin/",
+					// 		"permissions": "rw"
 					// },
 					// {
 					// 	"localPath": "${workspaceFolder}/actinia-parallel-plugin/",
@@ -107,8 +112,8 @@
 					// },
 					// {
 					// 	"localPath": "${workspaceFolder}/actinia-satellite-plugin/",
-					// 	"containerPath": "/src/actinia_satellite_plugin/",
-					// 	"permissions": "rw"
+					// 		"containerPath": "/src/actinia_satellite_plugin/",
+					// 		"permissions": "rw"
 					// },
 					// {
 					// 	"localPath": "${workspaceFolder}/actinia-stac-plugin/",

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ in `actinia-dev/Dockerfile` (see outcommented code) and mount local checkouts in
 container via `docker-compose-dev.yml` file (also see outcommented code).
 Build and run like described below and rebuild from your mounted source code:
 ```
-docker-compose -f docker-compose-dev.yml build
-docker-compose -f docker-compose-dev.yml run --rm --service-ports --entrypoint sh actinia
+docker compose -f docker-compose-dev.yml build
+docker compose -f docker-compose-dev.yml run --rm --service-ports --entrypoint sh actinia
 
 (cd /src/actinia_core && python3 setup.py install)
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ git config --global --add safe.directory /src/actinia-module-plugin
 # you can also run tests here, eg.
 (cd /src/actinia-module-plugin && python3 setup.py test)
 
-gunicorn -b 0.0.0.0:8088 -w 1 --access-logfile=- -k gthread actinia_core.main:flask_app
+# Includes creation of actinia-gdi user
+sh /src/start.sh
+# gunicorn -b 0.0.0.0:8088 -w 1 --access-logfile=- -k gthread actinia_core.main:flask_app
 ```
 
 To avoid cache problems, remove the packaged actinia_core (already done in Dockerfile)

--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ where the `config_path` is the file to the Keycloak OIDC JSON from the actinia c
 
 Then you can start the docker DEV setup as in [local dev-setup with docker](https://github.com/actinia-org/actinia-core/tree/main/docker#local-dev-setup-with-docker).
 ```
-docker-compose -f docker-compose-dev.yml build
+docker compose -f docker-compose-dev.yml build
 # start first postgis
-docker-compose -f docker-compose-dev.yml up -d postgis
+docker compose -f docker-compose-dev.yml up -d postgis
 # then start keycloak
-docker-compose -f docker-compose-dev.yml up -d keycloak
+docker compose -f docker-compose-dev.yml up -d keycloak
 ```
 
 By **first Keycloak setup** you have to load the inital keycloak data:

--- a/actinia-dev/Dockerfile
+++ b/actinia-dev/Dockerfile
@@ -29,6 +29,11 @@ RUN pip3 install -e .
 
 # for actinia plugin development, incomment matching block
 
+# RUN pip3 uninstall actinia_example_plugin.wsgi -y
+# RUN git clone https://github.com/actinia-org/actinia-example-plugin.git /src/actinia-example-plugin
+# WORKDIR /src/actinia-example-plugin/
+# RUN pip3 install -e .
+
 # RUN pip3 uninstall actinia_metadata_plugin.wsgi -y
 # RUN git clone https://github.com/actinia-org/actinia-metadata-plugin.git /src/actinia-metadata-plugin
 # WORKDIR /src/actinia-metadata-plugin/

--- a/actinia-dev/actinia.cfg
+++ b/actinia-dev/actinia.cfg
@@ -8,7 +8,7 @@ grass_gis_start_script = /usr/local/bin/grass
 grass_addon_path = /root/.grass8/addons/
 
 [API]
-plugins = ["actinia_statistic_plugin", "actinia_satellite_plugin", "actinia_metadata_plugin", "actinia_module_plugin", "actinia_stac_plugin"]
+plugins = ["actinia_example_plugin", "actinia_statistic_plugin", "actinia_satellite_plugin", "actinia_metadata_plugin", "actinia_module_plugin", "actinia_stac_plugin"]
 force_https_urls = False
 
 # [KEYCLOAK]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,6 +14,7 @@ services:
       - ./actinia-data/workspace/tmp:/actinia_core/workspace/tmp
       - ./actinia-data/resources:/actinia_core/resources
       - ../actinia-core:/src/actinia_core/.
+      # - ../actinia-example-plugin/:/src/actinia-example-plugin/.
       # - ../actinia_statistic_plugin/:/src/actinia_statistic_plugin/.
       # - ../actinia-metadata-plugin/:/src/actinia-metadata-plugin/.
       # - ../actinia-module-plugin/:/src/actinia-module-plugin/.
@@ -60,7 +61,7 @@ services:
     -   actinia-dev
 
   keycloak:
-    image: jboss/keycloak:16.1.1
+    image: quay.io/keycloak/keycloak:latest
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: ${KEYCLOAK_PW}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
       - ./actinia-data/workspace/temp_db:/actinia_core/workspace/temp_db
       - ./actinia-data/workspace/tmp:/actinia_core/workspace/tmp
       - ./actinia-data/resources:/actinia_core/resources
-      - ../actinia_core:/src/actinia_core/.
+      - ../actinia-core:/src/actinia_core/.
       # - ../actinia_statistic_plugin/:/src/actinia_statistic_plugin/.
       # - ../actinia-metadata-plugin/:/src/actinia-metadata-plugin/.
       # - ../actinia-module-plugin/:/src/actinia-module-plugin/.


### PR DESCRIPTION
Changes:
* Adjust `docker compose` (see also [here](https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2))
* Renaming of `actinia_core` into `actinia-core`
* add example-plugin for testing
* update deprecated keycloak version ( see also [here](https://stackoverflow.com/questions/76914407/which-docker-registry-should-be-used-for-keycloak) and recommendation within [keycloak-documentation](https://www.keycloak.org/server/containers): `quay.io/keycloak/keycloak:latest` ( https://hub.docker.com/r/jboss/keycloak/tags  → not available any longer)