### PR TITLE
Fix DEV-setup after adding example plugin

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -89,12 +89,12 @@
 						"containerPath": "/actinia_core/resources",
 						"permissions": "rw"
 					},
+					{
+						"localPath": "${workspaceFolder}/actinia-example-plugin/",
+					    "containerPath": "/src/actinia-example-plugin/",
+					    "permissions": "rw"
+					},
 					// mount plugin code on-demand
-					// {
-					// 	"localPath": "${workspaceFolder}/actinia-example-plugin/",
-					//     "containerPath": "/src/actinia-example-plugin/",
-					//     "permissions": "rw"
-					// },
 					// {
 					// 	"localPath": "${workspaceFolder}/actinia-metadata-plugin/",
 					//     "containerPath": "/src/actinia-metadata-plugin/",

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ sudo sysctl -w vm.max_map_count=262144
 
 For a dev setup where no actinia plugins are involved, simply follow the [steps explained in actinia-core](https://github.com/actinia-org/actinia-core/tree/main/docker#local-dev-setup-with-docker) directly. Instead of from `actinia_core/docker` run the steps from `actinia-docker`.
 
+
 ## Local dev-setup for actinia-core plugins
 For a local dev setup for actinia-core and actinia-core plugins
 (eg. actinia-actinia-metadata-plugin or actinia-module-plugin), uninstall them

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ sudo sysctl -w vm.max_map_count=262144
 
 For a dev setup where no actinia plugins are involved, simply follow the [steps explained in actinia-core](https://github.com/actinia-org/actinia-core/tree/main/docker#local-dev-setup-with-docker) directly. Instead of from `actinia_core/docker` run the steps from `actinia-docker`.
 
-
 ## Local dev-setup for actinia-core plugins
 For a local dev setup for actinia-core and actinia-core plugins
 (eg. actinia-actinia-metadata-plugin or actinia-module-plugin), uninstall them

--- a/actinia-dev/Dockerfile
+++ b/actinia-dev/Dockerfile
@@ -27,12 +27,12 @@ RUN git config --global --add safe.directory /src/actinia*
 WORKDIR /src/actinia_core/
 RUN pip3 install -e .
 
-# for actinia plugin development, incomment matching block
+RUN pip3 uninstall actinia_example_plugin.wsgi -y
+RUN git clone https://github.com/actinia-org/actinia-example-plugin.git /src/actinia-example-plugin
+WORKDIR /src/actinia-example-plugin/
+RUN pip3 install -e .
 
-# RUN pip3 uninstall actinia_example_plugin.wsgi -y
-# RUN git clone https://github.com/actinia-org/actinia-example-plugin.git /src/actinia-example-plugin
-# WORKDIR /src/actinia-example-plugin/
-# RUN pip3 install -e .
+# for actinia plugin development, incomment matching block
 
 # RUN pip3 uninstall actinia_metadata_plugin.wsgi -y
 # RUN git clone https://github.com/actinia-org/actinia-metadata-plugin.git /src/actinia-metadata-plugin

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,7 +14,7 @@ services:
       - ./actinia-data/workspace/tmp:/actinia_core/workspace/tmp
       - ./actinia-data/resources:/actinia_core/resources
       - ../actinia-core:/src/actinia_core/.
-      # - ../actinia-example-plugin/:/src/actinia-example-plugin/.
+      - ../actinia-example-plugin/:/src/actinia-example-plugin/.
       # - ../actinia_statistic_plugin/:/src/actinia_statistic_plugin/.
       # - ../actinia-metadata-plugin/:/src/actinia-metadata-plugin/.
       # - ../actinia-module-plugin/:/src/actinia-module-plugin/.


### PR DESCRIPTION
In a previous PR #97 the example-plugin was added as comment within `Dockerfile` and `docker-compose-dev.yaml`. Additionally it had to be added within `actinia.cfg` (of DEV-setup).

However, the DEV-setup is based on `mundialis/actinia`-docker-image, which does not include the example-plugin.
Thus for fixing DEV-setup either the actinia-example-plugin must be removed from `actinia.cfg` (of DEV-setup) and needs to be added in case the plugin is in development.
OR the example-plugin will be added by default to the DEV-setup as it's currently done within this PR.