### PR TITLE
Fix actinia-alpine docker build

### DIFF
--- a/actinia-alpine/Dockerfile
+++ b/actinia-alpine/Dockerfile
@@ -128,10 +128,13 @@ VOLUME /grassdb
 WORKDIR /src/actinia_core
 
 # install GDAL GRASS plugin (required for i.sentinel1.pyrosargeocode)
+RUN apk add cmake
 RUN mkdir -p /usr/lib/gdalplugins
 RUN git clone https://github.com/OSGeo/gdal-grass.git
-RUN cd gdal-grass && ./configure --with-gdal=/usr/bin/gdal-config --with-grass=/usr/local/grass84 \
-&& make && make install
+RUN cd gdal-grass \
+&& cmake -B build -DAUTOLOAD_DIR=/usr/lib/gdalplugins -DBUILD_TESTING=OFF \
+&& cmake --build build \
+&& cmake --install build
 RUN cd .. && rm -rf gdal-grass
 
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Fixed build of actinia-alpine docker, by:
- fixing installation of GDAL GRASS plugin (Autotools configure support removed, see [here](https://github.com/OSGeo/gdal-grass/pull/56); Fix, see [here](https://github.com/OSGeo/grass/pull/5106))