### PR TITLE
Add container names to dev setup

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,7 @@
 				]
 			},
 			"dockerRun": {
+				"containerName": "actinia-core",
 				"remove": true,
 				// network is needed when connecting to valkey
 				// while not using docker-compose for startup

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -33,6 +33,7 @@ services:
     -   actinia-dev
 
   valkey:
+    container_name: valkey
     image: valkey/valkey:9.0-alpine
     volumes:
       - ./valkey_data:/data


### PR DESCRIPTION
Tiny one. This helps when used in more complex dev setup with eg. [actinia-cloudevent-plugin](https://github.com/actinia-org/actinia-cloudevent-plugin), so that the container name is determinable.