### PR TITLE
Remove py3-rasterio to avoid vulnerable Pillow package

### DIFF
--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -95,7 +95,6 @@ ENV ACTINIA_RUNTIME_PACKAGES="\
     coreutils \
     rsync \
     py3-shapely \
-    py3-rasterio \
     py3-scikit-learn \
     valkey-cli \
     zip \


### PR DESCRIPTION
This PR removes the redundant Alpine `py3-rasterio` package.

Rasterio is already installed in the Python virtual environment through
the actinia-core dependencies. The Alpine package additionally pulls in
`py3-matplotlib`, which installs the vulnerable system packages
`py3-pillow` 12.2.0 and `py3-fonttools` 4.60.1.

After this change, Rasterio 1.5.0, Pillow 12.3.0, and fonttools 4.63.0
remain available in `/opt/venv`, while the vulnerable system
installations are removed.