### PR TITLE
Remove redundant system scikit-learn package

### DIFF
--- a/actinia-alpine/Dockerfile_alpine_dependencies
+++ b/actinia-alpine/Dockerfile_alpine_dependencies
@@ -96,7 +96,6 @@ ENV ACTINIA_RUNTIME_PACKAGES="\
     rsync \
     py3-shapely \
     py3-rasterio \
-    py3-scikit-learn \
     valkey-cli \
     zip \
     "


### PR DESCRIPTION
This PR removes the redundant Alpine `py3-scikit-learn` package.

Scikit-learn and joblib are already installed in `/opt/venv`. The Alpine
package additionally pulls in Dask and Distributed dependencies,
including the vulnerable system packages `py3-aiohttp` 3.13.5,
`py3-tornado` 6.5.5, and `py3-msgpack` 1.1.2.

After this change, scikit-learn and joblib remain available in
`/opt/venv`, while the vulnerable system installations are removed.